### PR TITLE
Account for FICA tax when calculating Profit Share Pool

### DIFF
--- a/PROFIT_SHARE_CALCULATOR/app/lib/seeds.js
+++ b/PROFIT_SHARE_CALCULATOR/app/lib/seeds.js
@@ -72,6 +72,7 @@ export default {
       actualLaborCost: 346502.51,
       projectedLaborCost: 345000,
       actualTotalPSUIssued: 84,
+      ficaPercentage: 0 // By mistake, we did not factor in FICA in 2017
     }
   }, {
     title: "2018",
@@ -84,6 +85,7 @@ export default {
       actualLaborCost: 653351,
       projectedLaborCost: 1008000,
       actualTotalPSUIssued: 139,
+      ficaPercentage: 0 // By mistake, we did not factor in FICA in 2018
     }
   }]
 }

--- a/PROFIT_SHARE_CALCULATOR/app/templates/application.hbs
+++ b/PROFIT_SHARE_CALCULATOR/app/templates/application.hbs
@@ -196,23 +196,7 @@
 
     <div class='brick col col-12 sm-col-6 py1 center'>
       <div class='border-medium-gray inner p2'>
-        <h3 class='serif lighter'>Total PSU Issued</h3>
-        <p>The total PSU issed across the team</p>
-        <h4>{{studio.totalPSUIssued}}</h4>
-      </div>
-    </div>
-
-    <div class='brick col col-12 sm-col-6 py1 center'>
-      <div class='border-medium-gray inner p2'>
-        <h3 class='serif lighter'>Value per PSU</h3>
-        <p>How much profit each PSU is worth this year</p>
-        <h4>{{format-money studio.actualValuePerPSU}}</h4>
-      </div>
-    </div>
-
-    <div class='brick col col-12 sm-col-6 py1 center'>
-      <div class='border-medium-gray inner p2'>
-        <h3 class='serif lighter'>Total Profit Share Pool</h3>
+        <h3 class='serif lighter'>Gross Profit Share Pool</h3>
         <p>The money put aside for for profit sharing</p>
         <h4>{{format-money studio.allowances.pool}}</h4>
       </div>
@@ -226,7 +210,53 @@
       </div>
     </div>
 
+    <div class='brick col col-12 sm-col-6 py1 center'>
+      <div class='border-medium-gray inner p2'>
+        <h3 class='serif lighter'>FICA Withholding*</h3>
+        <p>The money we'll be charged in FICA tax</p>
+        <h4>{{format-money studio.allowances.ficaWithholding}}</h4>
+      </div>
+    </div>
+
+    <div class='brick col col-12 sm-col-6 py1 center'>
+      <div class='border-medium-gray inner p2'>
+        <h3 class='serif lighter'>Profit Share Pool after FICA Withholding*</h3>
+        <p>The profit pool leaving our bank after FICA Withholding</p>
+        <h4>{{format-money studio.allowances.poolAfterFicaWithholding}}</h4>
+      </div>
+    </div>
+
+    <div class='brick col col-12 sm-col-6 py1 center'>
+      <div class='border-medium-gray inner p2'>
+        <h3 class='serif lighter'>Total PSU Issued</h3>
+        <p>The total PSU issed across the team</p>
+        <h4>{{studio.totalPSUIssued}}</h4>
+      </div>
+    </div>
+
+    <div class='brick col col-12 sm-col-6 py1 center'>
+      <div class='border-medium-gray inner p2'>
+        <h3 class='serif lighter'>Value per PSU</h3>
+        <p>How much profit each PSU is worth this year</p>
+        <h4>{{format-money studio.actualValuePerPSU}}</h4>
+      </div>
+    </div>
   </div>
+
+  <div class='clearfix px2 mb3'>
+    <h2>*A Note on FICA</h2>
+    <hr />
+    <p class='line-height'>
+    When paying bonuses, we need to account for <a href="https://www.accountingcoach.com/terms/F/federal-insurance-contributions-act" target="_blank">FICA tax</a>. FICA is an amount paid on on top of any payments to an employee of a business for the sake of Social Security and Medicare tax. Provided the employee hasn't made over a certain threshold with in tax year ($136k at the time of writing) the FICA tax is <strong>7.65%</strong>.
+    </p>
+    <p class='line-height'>
+    You may notice that FICA tax was not withheld in the year 2017 and 2018 historical scenarios. This was an oversight on my behalf! I had assumed this would be taken out by JustWorks when the payments were scheduled, but it was added on top of the bonuses for those years. In 2017, the FICA amount was low enough that I didn't notice, but in 2018 it was roughly $3,901.24. We endevour to pay out as much profit as humanly possible, while not putting the business at risk, so we need to start accounting for it at the time of this calculation.
+    </p>
+    <p>
+    - Hugh
+    </p>
+  </div>
+
   <div class='clearfix px2'>
     <div class='col col-12'>
       <img class='fit full' src='https://media.giphy.com/media/rBgYkVznFnkek/giphy.gif' />

--- a/PROFIT_SHARE_CALCULATOR/app/templates/components/info-brick.hbs
+++ b/PROFIT_SHARE_CALCULATOR/app/templates/components/info-brick.hbs
@@ -58,9 +58,9 @@
   <div class='brick dont-pad col col-12 sm-col-4 py1 center px2'>
     <div class='inner p2 border-medium-gray'>
       <h1 class='serif lighter'>2.</h1>
-      <h3 class='serif lighter'>Salary Cap @ 90k USD</h3>
+      <h3 class='serif lighter'>Salary Cap @ 110k USD</h3>
       <p class='line-height'>
-        All salaries at Sanctuary Computer are capped to 90k USD. A team member's
+        All salaries at Sanctuary Computer are capped to 110k USD. A team member's
         ability to earn a full salary depends on how close they are to seniority,
         in addition to a few other non-technical points.
       </p>

--- a/PROFIT_SHARE_CALCULATOR/app/templates/components/metrics-drawer.hbs
+++ b/PROFIT_SHARE_CALCULATOR/app/templates/components/metrics-drawer.hbs
@@ -33,6 +33,14 @@
   >
 </label>
 
+<label class='metric-input left-aligned block pb2'>
+    FICA Tax Percentage
+  <input
+    value={{studio.ficaPercentage}}
+    disabled=true
+  >
+</label>
+
 {{#if (eq studio.mode studio.Modes.MOCK)}}
   <label class='metric-input left-aligned block pb2'>
     Labor Cost (Computed)


### PR DESCRIPTION
In our first two years of sharing profit, I did not account for FICA tax. When paying bonuses (the way we distribute profit share), we were incurring an additional 7.65% fee to pay those bonuses out (roughly an extra $3,901 USD in 2018).

This was an oversight on my behalf when I first wrote the calculator code.

As our profit share pool is growing, this is becoming more important to calculate for. If I didn't account for it, this year (2019) we may end up pay like $8k or $9k extra, which risks our ability to make payroll in January. As such, we now need to absorb that amount in the profit share pool.

https://www.accountingcoach.com/terms/F/federal-insurance-contributions-act

![image](https://user-images.githubusercontent.com/2865404/68618295-01809c00-0497-11ea-9a3c-28a2b8053018.png)
** Please note, the values in this screenshot aren't indicative of anything real
