### PR TITLE
feat: updated PSU logic (WIP) 

### DIFF
--- a/PROFIT_SHARE_CALCULATOR/app/routes/application.js
+++ b/PROFIT_SHARE_CALCULATOR/app/routes/application.js
@@ -18,12 +18,10 @@ export default Route.extend({
               desiredPayrollBufferMonths: item.desired_buffer_months,
               income: item.gross_revenue,
               expenses: item.gross_expenses,
-              // TODO: replace placeholders (which are from 2022)
-              benefits: 329431.75,
-              subcontractors: 1151517.51,
-              preSpent: 26282.61,
-              preSpentReinvestment: 0,
-              //
+              benefits: item.gross_benefits,
+              subcontractors: item.subcontractors,
+              preSpent: item.pre_spent,
+              preSpentReinvestment: item.pre_spent_reinvestment,
               actualLaborCost: item.gross_payroll,
               // This isn't a true equivalency: projected_monthly_cost_of_doing_business takes
               // more than just payroll into account 

--- a/PROFIT_SHARE_CALCULATOR/app/routes/application.js
+++ b/PROFIT_SHARE_CALCULATOR/app/routes/application.js
@@ -18,7 +18,15 @@ export default Route.extend({
               desiredPayrollBufferMonths: item.desired_buffer_months,
               income: item.gross_revenue,
               expenses: item.gross_expenses,
+              // TODO: replace placeholders (which are from 2022)
+              benefits: 329431.75,
+              subcontractors: 1151517.51,
+              preSpent: 26282.61,
+              preSpentReinvestment: 0,
+              //
               actualLaborCost: item.gross_payroll,
+              // This isn't a true equivalency: projected_monthly_cost_of_doing_business takes
+              // more than just payroll into account 
               projectedLaborCost: item.projected_monthly_cost_of_doing_business,
               actualTotalPSUIssued: item.total_psu_issued,
               ficaPercentage: item.fica_tax_rate,

--- a/PROFIT_SHARE_CALCULATOR/app/services/studio.js
+++ b/PROFIT_SHARE_CALCULATOR/app/services/studio.js
@@ -168,7 +168,6 @@ export default Service.extend(
   // end
   /* Total cost of doing business */
   totalCostOfDoingBusiness: computed('actuallaborCost', 'expenses',  'benefits', 'subcontractors', 'preSpent', 'preSpentReinvestment', function() {
-    console.log(get(this, 'benefits'));
     return get(this, 'actualLaborCost') + get(this, 'expenses') + get(this, 'benefits') + get(this, 'subcontractors') - get(this, 'preSpent') - get(this, 'preSpentReinvestment');
   }).readOnly(),
 

--- a/PROFIT_SHARE_CALCULATOR/app/services/studio.js
+++ b/PROFIT_SHARE_CALCULATOR/app/services/studio.js
@@ -29,6 +29,10 @@ export default Service.extend(
   actualLaborCost: 0,
   projectedLaborCost: 0,
   actualTotalPSUIssued: 0,
+  benefits: 0,
+  subcontractors: 0,
+  preSpent: 0,
+  preSpentReinvestment: 0,
 
   reset() {
     this.setProperties({
@@ -47,8 +51,13 @@ export default Service.extend(
     });
   },
 
+  //   def raw_efficiency
+  //   @actuals[:gross_revenue].to_f / total_cost_of_doing_business
+  // end
   /* Computed Properties */
   rawEfficiency: computed('income', 'laborCost', 'expenses', function() {
+    if (get(this, 'mode') === Modes.REAL) return get(this, 'income') / (get(this, 'totalCostOfDoingBusiness'));
+
     return get(this, 'income') / (get(this, 'laborCost') + get(this, 'expenses'));
   }).readOnly(),
 
@@ -136,15 +145,31 @@ export default Service.extend(
     };
   }).readOnly(),
 
+  // TODO: rename me to reflect more than labor
   laborCost: computed('technologists.@each.salary', 'mode', 'actualLaborCost', function() {
     /* The Labor Cost attribute is concerned with determining the years
-     * effeciency, so in Modes.REAL we use the "actuaLaborCost" for that
+     * efficiency, so in Modes.REAL we use the "actualLaborCost" for that
      * year, rather than a computed projection, as the team may have changed
      * substantially that year.
      */
-    if (get(this, 'mode') === Modes.REAL) return get(this, 'actualLaborCost');
+    if (get(this, 'mode') === Modes.REAL) return get(this, 'totalCostOfDoingBusiness');
 
+    /* Modes.MOCK doesn't take anything other than payroll into account for cost*/
     return get(this, 'technologists').reduce((a, tech) => a + get(tech, 'laborCostThisYear'), 0);
+  }).readOnly(),
+
+    //   def total_cost_of_doing_business
+  //   @actuals[:gross_payroll].to_f +
+  //   @actuals[:gross_expenses].to_f +
+  //   @actuals[:gross_benefits].to_f +
+  //   @actuals[:gross_subcontractors].to_f -
+  //   @pre_spent - # Don't count prespent profit share against this
+  //   @pre_spent_reinvestment # Don't count prespent reinvestment against this
+  // end
+  /* Total cost of doing business */
+  totalCostOfDoingBusiness: computed('actuallaborCost', 'expenses',  'benefits', 'subcontractors', 'preSpent', 'preSpentReinvestment', function() {
+    console.log(get(this, 'benefits'));
+    return get(this, 'actualLaborCost') + get(this, 'expenses') + get(this, 'benefits') + get(this, 'subcontractors') - get(this, 'preSpent') - get(this, 'preSpentReinvestment');
   }).readOnly(),
 
   monthlyLaborCost: computed('laborCost', 'mode', 'projectedLaborCost', function() {
@@ -152,6 +177,8 @@ export default Service.extend(
      * so in Modes.REAL we use the most "up to date" projection for
      * salary costing, rather than actualLaborCost.
      */
+    // This is really projected_monthly_cost_of_doing_business in Stacks, which takes 
+    // more than labor into account
     if (get(this, 'mode') === Modes.REAL) return (get(this, 'projectedLaborCost') / 12);
     return get(this, 'laborCost') / 12;
   }).readOnly(),

--- a/PROFIT_SHARE_CALCULATOR/app/templates/components/metrics-drawer.hbs
+++ b/PROFIT_SHARE_CALCULATOR/app/templates/components/metrics-drawer.hbs
@@ -50,7 +50,37 @@
     Total PSU Issued (Computed)
     {{input value=studio.totalPSUIssued disabled=true}}
   </label>
-{{else}}
+{{/if}}  
+{{#if (eq studio.mode studio.Modes.REAL)}}
+<label class='metric-input left-aligned block pb2'>
+    Benefits
+    <input
+      value={{studio.benefits}}
+      oninput={{action 'setNumeric' 'benefits'}}
+    >
+  </label>
+  <label class='metric-input left-aligned block pb2'>
+    Subcontractors
+    <input
+      value={{studio.subcontractors}}
+      oninput={{action 'setNumeric' 'subcontractors'}}
+    >
+  </label>
+    <label class='metric-input left-aligned block pb2'>
+    Pre-spent profit share
+    <input
+      value={{studio.preSpent}}
+      oninput={{action 'setNumeric' 'pre_spent'}}
+    >
+  </label>
+  <label class='metric-input left-aligned block pb2'>
+    Pre-spent reinvestment budget
+    <input
+      value={{studio.preSpentReinvestment}}
+      oninput={{action 'setNumeric' 'pre_spent_reinvestment'}}
+    >
+  </label>
+{{/if}}  
   <label class='metric-input left-aligned block pb2'>
     Actualized Labor Cost
     <input
@@ -59,7 +89,7 @@
     >
   </label>
   <label class='metric-input left-aligned block pb2'>
-    Projected Labor Cost
+    Projected Monthly Cost of Doing Business
     <input
       value={{studio.projectedLaborCost}}
       oninput={{action 'setNumeric' 'projectedLaborCost'}}
@@ -72,4 +102,3 @@
       oninput={{action 'setNumeric' 'actualTotalPSUIssued'}}
     >
   </label>
-{{/if}}

--- a/PROFIT_SHARE_CALCULATOR/config/environment.js
+++ b/PROFIT_SHARE_CALCULATOR/config/environment.js
@@ -32,7 +32,7 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
 
-    // ENV.stacksOrigin = 'http://localhost:3000/api/profit_share_passes';
+    ENV.stacksOrigin = 'http://localhost:3000/api/profit_share_passes';
   }
 
   if (environment === 'test') {

--- a/PROFIT_SHARE_CALCULATOR/config/environment.js
+++ b/PROFIT_SHARE_CALCULATOR/config/environment.js
@@ -32,7 +32,7 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
 
-    ENV.stacksOrigin = 'http://localhost:3000/api/profit_share_passes';
+    // ENV.stacksOrigin = 'http://localhost:3000/api/profit_share_passes';
   }
 
   if (environment === 'test') {


### PR DESCRIPTION
Builds on https://github.com/sanctuarycomputer/studio/pull/91 (wherein PSU value calculated for years > 2020 were incorrect). 

Current status of this branch is that it's WIP because 
- [ ] Needs code cleanup (see TODO comments in code)
- [ ] PSU value is correct for latter years but now incorrect for earlier years (2020 is the cutoff I believe but would double check) 

Twist thread with context: https://twist.com/a/133876/ch/695164/t/5973378/